### PR TITLE
fix: 修复无法加载私钥时异常抛出方式

### DIFF
--- a/src/TLSSigAPI.php
+++ b/src/TLSSigAPI.php
@@ -54,7 +54,8 @@ class TLSSigAPI {
     public function setPublicKey($public_key) {
         $this->public_key = openssl_pkey_get_public($public_key);
         if ($this->public_key === false) {
-            throw new \Exception(openssl_error_string());
+            $error = error_get_last();
+            throw new \Exception($error['message'], $error['type']);
         }
         return true;
     }

--- a/src/TLSSigAPI.php
+++ b/src/TLSSigAPI.php
@@ -40,7 +40,8 @@ class TLSSigAPI {
     public function setPrivateKey($private_key) {
         $this->private_key = openssl_pkey_get_private($private_key);
         if ($this->private_key === false) {
-            throw new \Exception(openssl_error_string());
+            $error = error_get_last();
+            throw new \Exception($error['message'], $error['type']);
         }
         return true;
     }


### PR DESCRIPTION
使用 error_get_last() 函数替代 openssl_error_string() 以在无法加载密钥（如路径错误）时抛出正确的异常信息